### PR TITLE
fix: no longer returning escaped keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,16 @@ objectScan(["a.*.f"])({ a: { b: { c: 'd' }, e: { f: 'g' } } });
 // => [ 'a.e.f' ]
 ```
 
+### Value Function
+
+Constructor takes second value function parameter which gets passed in the value of the key and is expected to return true or false.
+Only results where the value function returns true are returned.
+
+### Joined
+
+When dealing with special characters it might be desired to not have the output merged. In this case 
+the constructor takes a third option which can be set to false to return each key as a list.
+
 ## Examples
 
 More extensive examples can be found in the tests.
@@ -62,6 +72,8 @@ objectScan(["*.*.*"])(obj);
 // or filter
 objectScan(["a.*.{c,f}"])(obj);
 // => ["a.b.c", "a.e.f"]
+objectScan(["a.*.{c,f}"], () => true, false)(obj);
+// => [["a", "b", "c"], ["a", "e", "f"]]
 
 // list filter
 objectScan(["*.*[*]"])(obj);
@@ -86,3 +98,5 @@ objectScan(["**"], e => typeof e === "string")(obj);
 
 The following Characters are considered special and need to 
 be escaped if they should be matched in a key: `[`, `]`, `{`, `}`, `,`, `.` and `*`. 
+
+When dealing with special characters the `joined` option might be desirable to set to `false`.

--- a/src/index.js
+++ b/src/index.js
@@ -1,13 +1,16 @@
 const parser = require("./util/parser");
 
-module.exports = (needles, valueFn = undefined) => {
+module.exports = (needles, valueFn = undefined, joined = true) => {
   const search = needles.map(parser);
 
-  const find = (haystack, checks, pathIn = undefined) => {
+  const find = (haystack, checks, pathIn = []) => {
     const result = [];
     if (checks.some(check => check.length === 0)) {
       if (valueFn === undefined || valueFn(haystack)) {
-        result.push(pathIn);
+        result.push(joined ? pathIn.reduce((p, c) => {
+          const isNumber = typeof c === "number";
+          return `${p}${p === "" || isNumber ? "" : "."}${isNumber ? `[${c}]` : c}`;
+        }, "") : pathIn);
       }
     }
     if (haystack instanceof Object) {
@@ -16,7 +19,7 @@ module.exports = (needles, valueFn = undefined) => {
           checks
             .filter(check => check.length !== 0)
             .forEach((check) => {
-              const pathOut = `${pathIn === undefined ? "" : pathIn}[${i}]`;
+              const pathOut = [].concat(...pathIn).concat(i);
               if (check[0] === "**") {
                 result.push(...find(haystack[i], [check, check.slice(1)], pathOut));
               } else if (
@@ -34,7 +37,7 @@ module.exports = (needles, valueFn = undefined) => {
             .filter(check => check.length !== 0)
             .forEach((check) => {
               const escapedKey = key.replace(/[,.*[\]{}]/g, "\\$&");
-              const pathOut = pathIn === undefined ? escapedKey : `${pathIn}.${escapedKey}`;
+              const pathOut = [].concat(...pathIn).concat(key);
               if (check[0] === "**") {
                 result.push(...find(haystack[key], [check, check.slice(1)], pathOut));
               } else if (

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -75,6 +75,15 @@ describe("Testing Find", () => {
     ]);
   });
 
+  it("Testing Path Double Star (Separated)", () => {
+    const find = objectScan(["**.child"], undefined, false);
+    expect(find(haystack)).to.deep.equal([
+      ["parent1", "child"],
+      ["parent2", "child"],
+      ["grandparent1", "parent", "child"]
+    ]);
+  });
+
   it("Testing Array Top Level", () => {
     const find = objectScan(["[*]"]);
     expect(find(haystack.array1)).to.deep.equal([
@@ -137,34 +146,32 @@ describe("Testing Find", () => {
   it("Testing Escaped Char Matching", () => {
     [',', '.', '*', '[', ']', '{', '}'].forEach((char) => {
       const find = objectScan([`\\${char}`]);
-      expect(find({ [char]: "a", b: "c" })).to.deep.equal([
-        `\\${char}`
-      ]);
+      expect(find({ [char]: "a", b: "c" })).to.deep.equal([char]);
     });
   });
 
   it("Testing Escaped Star", () => {
     const find = objectScan([`a.\\[\\*\\]`]);
     expect(find({ a: { "[*]": "b", "[x]": "c" } })).to.deep.equal([
-      "a.\\[\\*\\]"
+      "a.[*]"
     ]);
   });
 
   it("Testing Escaped Comma", () => {
     const find = objectScan([`{a\\,b,c\\,d,f\\\\\\,g}`]);
     expect(find({ "a,b": "c", "c,d": "e", "f\\\\,g": "h" })).to.deep.equal([
-      "a\\,b",
-      "c\\,d",
-      "f\\\\\\,g"
+      "a,b",
+      "c,d",
+      "f\\\\,g"
     ]);
   });
 
   it("Testing Escaped Dot", () => {
     const find = objectScan([`{a\\.b,c\\.d,f\\\\\\.g}`]);
     expect(find({ "a.b": "c", "c.d": "e", "f\\\\.g": "h" })).to.deep.equal([
-      "a\\.b",
-      "c\\.d",
-      "f\\\\\\.g"
+      "a.b",
+      "c.d",
+      "f\\\\.g"
     ]);
   });
 
@@ -172,6 +179,7 @@ describe("Testing Find", () => {
     const input = { a: { b: { c: 'd' }, e: { f: 'g' }, h: ["i", "j"] }, k: "l" };
     expect(objectScan(["*"])(input)).to.deep.equal(["a", "k"]);
     expect(objectScan(["a.*.{c,f}"])(input)).to.deep.equal(["a.b.c", "a.e.f"]);
+    expect(objectScan(["a.*.{c,f}"], () => true, false)(input)).to.deep.equal([["a", "b", "c"], ["a", "e", "f"]]);
     expect(objectScan(["a.*.f"])(input)).to.deep.equal(["a.e.f"]);
     expect(objectScan(["*.*.*"])(input)).to.deep.equal(["a.b.c", "a.e.f"]);
     expect(objectScan(["**"])(input)).to


### PR DESCRIPTION
feat: added option to return matches as lists (to better deal with special characters)